### PR TITLE
invite acceptor is not required

### DIFF
--- a/guardduty.tf
+++ b/guardduty.tf
@@ -1,8 +1,3 @@
 resource "aws_guardduty_detector" "member" {
   enable = true
 }
-
-resource "aws_guardduty_invite_accepter" "member" {
-  detector_id       = aws_guardduty_detector.member.id
-  master_account_id = var.admin_account_id
-}


### PR DESCRIPTION
- the invite acceptor resource is not required by UPowr and causes the depeloyment to fail